### PR TITLE
Fix CRAN errors

### DIFF
--- a/vignettes/entropy_np.Rnw
+++ b/vignettes/entropy_np.Rnw
@@ -69,7 +69,7 @@
 
 <<eval=TRUE,echo=FALSE,results=hide,keep.source=TRUE>>=
 library(np)
-options(prompt = "R> ", np.messages = FALSE, digits = 3)
+options(prompt = "R> ", np.messages = FALSE, digits = 3, warn = -1)
 @ 
 
 %% Achim asks for making use of <<..., height= ..., width = ...>>= for

--- a/vignettes/entropy_np.Rnw
+++ b/vignettes/entropy_np.Rnw
@@ -11,7 +11,7 @@
 %% need no \usepackage{Sweave.sty}
 
 \usepackage{amsmath,amsfonts}
-\usepackage[utf8x]{inputenc} 
+\usepackage[utf8]{inputenc} 
 
 \newcommand{\field}[1]{\mathbb{#1}}
 \newcommand{\N}{\field{N}}

--- a/vignettes/np.Rnw
+++ b/vignettes/np.Rnw
@@ -11,7 +11,7 @@
 %% need no \usepackage{Sweave.sty}
 
 \usepackage{amsmath}
-\usepackage[utf8x]{inputenc} 
+\usepackage[utf8]{inputenc} 
 
 \newcommand{\field}[1]{\mathbb{#1}}
 \newcommand{\R}{\field{R}}
@@ -1444,7 +1444,7 @@ model.scoef <- npscoef(lwage ~ dfemale +
                        dmarried +
                        educ +
                        exper +
-                       tenure | female,
+                       tenure | dfemale,
                        betas = TRUE,
                        data = wage1.augmented)
 summary(model.scoef)

--- a/vignettes/np.Rnw
+++ b/vignettes/np.Rnw
@@ -88,7 +88,7 @@
 %% paper
 
 <<eval=TRUE,echo=FALSE,keep.source=TRUE>>=
-options(prompt = "R> ", np.messages = FALSE, digits = 3)
+options(prompt = "R> ", np.messages = FALSE, digits = 3, warn = -1)
 @ 
 
 %% Achim asks for making use of <<..., height= ..., width = ...>>= for
@@ -1444,7 +1444,7 @@ model.scoef <- npscoef(lwage ~ dfemale +
                        dmarried +
                        educ +
                        exper +
-                       tenure | dfemale,
+                       tenure | female,
                        betas = TRUE,
                        data = wage1.augmented)
 summary(model.scoef)

--- a/vignettes/np_faq.Rnw
+++ b/vignettes/np_faq.Rnw
@@ -374,7 +374,7 @@ bw.mat <- matrix(NA,nrow=num.res,ncol=2)
 
 ## Get the scale factors for resamples from the full sample of size n.sub
 
-options(np.messages=FALSE)
+options(np.messages=FALSE, warn = -1)
 
 for(i in 1:num.res)  {
 


### PR DESCRIPTION
This PR attempts to fix [build errors noted on CRAN](https://cran.r-project.org/web/checks/check_results_np.html) and noted in #37.

There are two fixes needed:

__1. Change model formula in `np.Rnw`__

I am not sure the intention of this model formula.
```r
model.scoef <- npscoef(lwage ~ dfemale +
                       dmarried +
                       educ +
                       exper +
                       tenure | female,
                       betas = TRUE,
                       data = wage1.augmented)
```
but the CRAN error is related to the `tenure | female` line, apparently because `female` is a factor. I changed to the integer-valued `dfemale` and it seems to fix the error.

__2. Changing `utf` encoding in `inputenc`__

The error regarding extra characters with Ahat character seems to be related to the use of the line

```latex
\usepackage[utf8x]{inputenc} 
```

According to [this StackOverflow answer](https://tex.stackexchange.com/a/203804), utf8x is no longer needed and utf8 can be used instead.


I have used RHub build on `debian-gcc-devel` and it builds successfully without error. I haven't checked the other architectures, but given that the warnings are the same, I anticipate that these changes will correct them.

I am a big fan of this package and it'd be a shame to see it archived. Please let me know if you need additional help to make sure it stays on CRAN.

