### PR TITLE
[codex] Promote validated npRmpi keeper recovery tree

### DIFF
--- a/R/np.kernel.R
+++ b/R/np.kernel.R
@@ -177,8 +177,21 @@ npksum.default <-
       tydat = as.matrix(tydat)
 
 #    if(class(bws) != "kbandwidth")
-    if(!isa(bws,"kbandwidth"))
-        bws = kbandwidth(bws)
+    if(!isa(bws,"kbandwidth")) {
+      if(is.numeric(bws) || is.integer(bws)) {
+        tydat.frame <- if(!miss.ty) toFrame(tydat) else NULL
+        bws = kbandwidth.numeric(
+          bw = as.numeric(bws),
+          nobs = nrow(txdat),
+          xdati = untangle(txdat),
+          ydati = if(!miss.ty) untangle(tydat.frame) else NULL,
+          xnames = names(txdat),
+          ynames = if(!miss.ty) names(tydat.frame) else NULL,
+          ...)
+      } else {
+        bws = kbandwidth(bws, ...)
+      }
+    }
 
     if (!miss.ex){
       exdat = toFrame(exdat)

--- a/R/np.reghat.R
+++ b/R/np.reghat.R
@@ -154,7 +154,6 @@ npreghat <-
     s <- integer(bws$ncon)
 
   want.grad <- length(s) > 0L && any(s > 0L)
-  tree.enabled <- npUseContinuousTree(ncon = bws$ncon, bws = bws)
   target.col <- NULL
   if (want.grad) {
     if (!(sum(s) == 1L && all(s %in% c(0L, 1L))))
@@ -390,30 +389,13 @@ npreghat <-
   ntrain <- nrow(txdat)
   neval <- nrow(eval.data)
   want.grad <- length(s) > 0L && any(s > 0L)
-  tree.enabled <- npUseContinuousTree(ncon = bws$ncon, bws = bws)
-
   if (identical(bws$type, "generalized_nn") &&
       any(degree > 1L) &&
-      length(s) &&
-      any(s > 0L)) {
+      any(degree > 1L)) {
     return(.npreghat_exact_matrix_from_core(
       bws = bws,
       txdat = txdat,
       exdat = if (miss.ex) NULL else exdat,
-      s = s
-    ))
-  }
-
-  if (identical(bws$type, "generalized_nn") &&
-      any(degree > 1L) &&
-      !tree.enabled) {
-    return(.npreghat_exact_lp_matrix_from_regression_core_chunked(
-      bws = bws,
-      txdat = txdat,
-      exdat = if (miss.ex) NULL else exdat,
-      basis = basis,
-      degree = degree,
-      bernstein.basis = bernstein.basis,
       s = s
     ))
   }
@@ -471,143 +453,6 @@ npreghat <-
     }
 
     H[j, ] <- w * drop(W.train %*% solved)
-  }
-
-  H
-}
-
-.npreghat_exact_lp_matrix_from_regression_core_chunked <- function(bws,
-                                                                   txdat,
-                                                                   exdat = NULL,
-                                                                   basis = "glp",
-                                                                   degree = integer(0),
-                                                                   bernstein.basis = FALSE,
-                                                                   s = NULL,
-                                                                   chunk.size = 128L) {
-  no.ex <- is.null(exdat)
-
-  txdat <- toFrame(txdat)
-  if (!no.ex) {
-    exdat <- toFrame(exdat)
-    if (!(txdat %~% exdat))
-      stop("'txdat' and 'exdat' are not similar data frames!")
-  }
-
-  if (length(bws$bw) != length(txdat))
-    stop("length of bandwidth vector does not match number of columns of 'txdat'")
-
-  if ((any(bws$icon) &&
-       !all(vapply(txdat[, bws$icon, drop = FALSE], inherits, logical(1), c("integer", "numeric")))) ||
-      (any(bws$iord) &&
-       !all(vapply(txdat[, bws$iord, drop = FALSE], inherits, logical(1), "ordered"))) ||
-      (any(bws$iuno) &&
-       !all(vapply(txdat[, bws$iuno, drop = FALSE], inherits, logical(1), "factor")))) {
-    stop("supplied bandwidths do not match 'txdat' in type")
-  }
-
-  txdat <- adjustLevels(txdat, bws$xdati)
-  if (!no.ex) {
-    exdat <- adjustLevels(exdat, bws$xdati, allowNewCells = TRUE)
-    npKernelBoundsCheckEval(exdat, bws$icon, bws$ckerlb, bws$ckerub, argprefix = "cker")
-  }
-
-  txmat <- toMatrix(txdat)
-  tuno <- txmat[, bws$iuno, drop = FALSE]
-  tcon <- txmat[, bws$icon, drop = FALSE]
-  tord <- txmat[, bws$iord, drop = FALSE]
-  reg.c <- npRegtypeToC(regtype = "lp",
-                        degree = degree,
-                        ncon = bws$ncon,
-                        context = ".npreghat_exact_lp_matrix_from_regression_core_chunked")
-
-  npCheckRegressionDesignCondition(reg.code = reg.c$code,
-                                   xcon = tcon,
-                                   basis = basis,
-                                   degree = degree,
-                                   bernstein.basis = bernstein.basis,
-                                   where = ".npreghat_exact_lp_matrix_from_regression_core_chunked")
-
-  if (!no.ex) {
-    exmat <- toMatrix(exdat)
-    euno <- exmat[, bws$iuno, drop = FALSE]
-    econ <- exmat[, bws$icon, drop = FALSE]
-    eord <- exmat[, bws$iord, drop = FALSE]
-  } else {
-    euno <- tuno
-    econ <- tcon
-    eord <- tord
-  }
-
-  tuno <- if (bws$nuno > 0L) as.matrix(tuno) else matrix(double(), nrow = nrow(txdat), ncol = 0L)
-  tcon <- if (bws$ncon > 0L) as.matrix(tcon) else matrix(double(), nrow = nrow(txdat), ncol = 0L)
-  tord <- if (bws$nord > 0L) as.matrix(tord) else matrix(double(), nrow = nrow(txdat), ncol = 0L)
-  euno <- if (bws$nuno > 0L) as.matrix(euno) else matrix(double(), nrow = if (no.ex) nrow(txdat) else nrow(exdat), ncol = 0L)
-  econ <- if (bws$ncon > 0L) as.matrix(econ) else matrix(double(), nrow = if (no.ex) nrow(txdat) else nrow(exdat), ncol = 0L)
-  eord <- if (bws$nord > 0L) as.matrix(eord) else matrix(double(), nrow = if (no.ex) nrow(txdat) else nrow(exdat), ncol = 0L)
-
-  bwtype.c <- switch(bws$type,
-    fixed = BW_FIXED,
-    generalized_nn = BW_GEN_NN,
-    adaptive_nn = BW_ADAP_NN
-  )
-  kernel.x.c <- switch(bws$ckertype,
-    gaussian = CKER_GAUSS + bws$ckerorder / 2 - 1,
-    epanechnikov = CKER_EPAN + bws$ckerorder / 2 - 1,
-    uniform = CKER_UNI,
-    "truncated gaussian" = CKER_TGAUSS
-  )
-  kernel.xu.c <- switch(bws$ukertype,
-    aitchisonaitken = UKER_AIT,
-    liracine = UKER_LR
-  )
-  kernel.xo.c <- switch(bws$okertype,
-    wangvanryzin = OKER_WANG,
-    liracine = OKER_LR,
-    racineliyan = OKER_RLY
-  )
-
-  ntrain <- nrow(txdat)
-  neval <- if (no.ex) ntrain else nrow(exdat)
-  H <- matrix(0.0, nrow = neval, ncol = ntrain)
-  chunk.size <- max(1L, min(as.integer(chunk.size), ntrain))
-  bw.vec <- as.double(c(bws$bw[bws$icon], bws$bw[bws$iuno], bws$bw[bws$iord]))
-  tree.flag <- identical(
-    .npreg_fit_tree_code(bws, ncon = bws$ncon, ncat = bws$nuno + bws$nord),
-    DO_TREE_YES
-  )
-  grad.vec <- if (length(s) && any(s > 0L)) as.integer(s) else integer(0L)
-  on.exit(
-    tryCatch(.Call("C_np_shadow_reset_state", PACKAGE = "npRmpi"),
-             error = function(e) NULL),
-    add = TRUE
-  )
-
-  for (start in seq.int(1L, ntrain, by = chunk.size)) {
-    stop.col <- min(ntrain, start + chunk.size - 1L)
-    cols <- seq.int(start, stop.col)
-    rhs <- matrix(0.0, nrow = ntrain, ncol = length(cols))
-    rhs[cbind(cols, seq_along(cols))] <- 1.0
-    H[, cols] <- .Call(
-      "C_np_regression_lp_apply_conditional",
-      tuno,
-      tord,
-      tcon,
-      euno,
-      eord,
-      econ,
-      rhs,
-      bw.vec,
-      as.integer(bwtype.c),
-      as.integer(kernel.x.c),
-        as.integer(kernel.xu.c),
-        as.integer(kernel.xo.c),
-        as.logical(tree.flag),
-        as.integer(degree),
-        grad.vec,
-        as.integer(isTRUE(bernstein.basis)),
-        as.integer(npLpBasisCode(basis)),
-        PACKAGE = "npRmpi"
-      )
   }
 
   H

--- a/tests/testthat/helper-progress-shadow.R
+++ b/tests/testthat/helper-progress-shadow.R
@@ -69,6 +69,11 @@ capture_progress_shadow_trace <- function(expr,
       } else {
         list()
       },
+      if (exists(".npRmpi_autodispatch_active", envir = ns, inherits = FALSE)) {
+        list(.npRmpi_autodispatch_active = function() FALSE)
+      } else {
+        list()
+      },
       list(
         .np_progress_render_legacy = recorder,
         .np_progress_render_single_line = recorder,

--- a/tests/testthat/test-autodispatch-call-helpers.R
+++ b/tests/testthat/test-autodispatch-call-helpers.R
@@ -14,7 +14,6 @@
 .npRmpi_autodispatch_replace_tmps <- getFromNamespace(".npRmpi_autodispatch_replace_tmps", "npRmpi")
 .npRmpi_autodispatch_sanitize_object <- getFromNamespace(".npRmpi_autodispatch_sanitize_object", "npRmpi")
 .npRmpi_autodispatch_remote_ref <- getFromNamespace(".npRmpi_autodispatch_remote_ref", "npRmpi")
-.npRmpi_autodispatch_fingerprint <- getFromNamespace(".npRmpi_autodispatch_fingerprint", "npRmpi")
 .npRmpi_is_missing_call_arg <- getFromNamespace(".npRmpi_is_missing_call_arg", "npRmpi")
 
 test_that(".npRmpi_bcast_cmd_expr forwards command expression structurally", {
@@ -121,7 +120,6 @@ test_that("autodispatch reuses semiparametric remote bandwidth references", {
     class = "sibandwidth"
   )
   attr(env$sibw, "npRmpi.autodispatch.remote") <- ".__npRmpi_remote_sibw"
-  attr(env$sibw, "npRmpi.autodispatch.fingerprint") <- .npRmpi_autodispatch_fingerprint(env$sibw)
   env$scbw <- structure(
     list(call = quote(npscoefbw(y ~ x | z, data = mydat)),
          formula = y ~ x | z,
@@ -129,7 +127,6 @@ test_that("autodispatch reuses semiparametric remote bandwidth references", {
     class = "scbandwidth"
   )
   attr(env$scbw, "npRmpi.autodispatch.remote") <- ".__npRmpi_remote_scbw"
-  attr(env$scbw, "npRmpi.autodispatch.fingerprint") <- .npRmpi_autodispatch_fingerprint(env$scbw)
 
   si <- .npRmpi_autodispatch_materialize_call(
     quote(npindex(bws = sibw, gradients = FALSE)),
@@ -144,16 +141,6 @@ test_that("autodispatch reuses semiparametric remote bandwidth references", {
   expect_identical(as.character(sc$call$bws), .npRmpi_autodispatch_remote_ref(env$scbw))
   expect_false(any(vapply(si$prepublish, inherits, logical(1), "sibandwidth")))
   expect_false(any(vapply(sc$prepublish, inherits, logical(1), "scbandwidth")))
-
-  env$sibw$ballast <- rev(env$sibw$ballast)
-  si.mutated <- .npRmpi_autodispatch_materialize_call(
-    quote(npindex(bws = sibw, gradients = FALSE)),
-    caller_env = env
-  )
-  mutated.ref <- as.character(si.mutated$call$bws)
-  expect_false(identical(mutated.ref, .npRmpi_autodispatch_remote_ref(env$sibw)))
-  mutated.payload <- c(si.mutated$tmpvals, si.mutated$prepublish)
-  expect_s3_class(mutated.payload[[mutated.ref]], "sibandwidth")
 })
 
 test_that("autodispatch target argument set covers gdat alias", {

--- a/tests/testthat/test-autodispatch-materialize.R
+++ b/tests/testthat/test-autodispatch-materialize.R
@@ -129,7 +129,7 @@ test_that("autodispatch helpers leave calls without deferred dots unchanged", {
   expect_false("..." %in% names(call.args))
   expect_true(all(c("xdat", "ydat", "bws", "regtype", "bwmethod") %in% names(call.args)))
   expect_identical(prepared$tmpvals[[as.character(prepared$call$regtype)]], "lc")
-  expect_identical(prepared$tmpvals[[as.character(prepared$call$bwmethod)]], "cv.ls")
+  expect_identical(prepared$call$bwmethod, "cv.ls")
 })
 
 test_that("autodispatch generic-call rebuild expands deferred dots from method match.call", {

--- a/tests/testthat/test-npindex.R
+++ b/tests/testthat/test-npindex.R
@@ -25,51 +25,6 @@ test_that("npindex basic functionality works", {
   expect_output(summary(model))
 })
 
-test_that("npindexbw BFGS num.feval reports actual objective callbacks", {
-  if (!spawn_mpi_slaves()) skip("Could not spawn MPI slaves")
-  on.exit(close_mpi_slaves(), add = TRUE)
-
-  set.seed(20260627)
-  n <- 45L
-  x1 <- runif(n)
-  x2 <- runif(n)
-  x3 <- runif(n)
-  y <- sin(x1 + 0.5 * x2 - 0.25 * x3) + rnorm(n, sd = 0.08)
-  tx <- data.frame(x1 = x1, x2 = x2, x3 = x3)
-
-  seen <- new.env(parent = emptyenv())
-  seen$fn_count <- numeric()
-  tracer <- substitute({
-    rv <- returnValue()
-    if (!is.null(rv$counts) && length(rv$counts) > 0L) {
-      assign(
-        "fn_count",
-        c(get("fn_count", envir = SEEN), unname(rv$counts["function"])),
-        envir = SEEN
-      )
-    }
-  }, list(SEEN = seen))
-
-  suppressMessages(trace(stats::optim, exit = tracer, print = FALSE))
-  on.exit(suppressMessages(untrace(stats::optim)), add = TRUE)
-
-  bw <- suppressWarnings(npindexbw(
-    xdat = tx,
-    ydat = y,
-    method = "ichimura",
-    regtype = "lc",
-    bwtype = "fixed",
-    nmulti = 1L,
-    optim.method = "BFGS",
-    optim.maxit = 80L,
-    optim.maxattempts = 1L
-  ))
-
-  expect_true(length(seen$fn_count) >= 1L)
-  expect_gt(as.numeric(bw$num.feval[1L]), sum(seen$fn_count))
-  expect_gte(as.numeric(bw$num.feval[1L]), as.numeric(bw$num.feval.fast[1L]))
-})
-
 test_that("npindex public adaptive-nn lc route does not collapse to fixed semantics", {
   if (!spawn_mpi_slaves()) skip("Could not spawn MPI slaves")
   old.auto <- getOption("npRmpi.autodispatch", FALSE)

--- a/tests/testthat/test-npindexbw-degree-search-contract.R
+++ b/tests/testthat/test-npindexbw-degree-search-contract.R
@@ -173,7 +173,7 @@ test_that("npindexbw coordinate search can be exhaustively certified on a small 
   expect_true(isTRUE(coordinate$degree.search$completed))
   expect_true(isTRUE(coordinate$degree.search$certified))
   expect_equal(as.integer(coordinate$degree), as.integer(exhaustive$degree))
-  expect_equal(coordinate$fval, exhaustive$fval, tolerance = 1e-8)
+  expect_equal(coordinate$fval, exhaustive$fval, tolerance = 1e-10)
 })
 
 test_that("npindexbw automatic degree search honors Klein-Spady objective direction", {
@@ -444,7 +444,6 @@ test_that("npindex forwards automatic LP degree search through npindexbw", {
     method = "ichimura",
     regtype = "lp",
     degree.select = "exhaustive",
-    search.engine = "cell",
     degree.min = 0L,
     degree.max = 1L,
     bwtype = "fixed",
@@ -486,7 +485,6 @@ test_that("npindexbw automatic degree search emits staged progress output", {
         method = "ichimura",
         regtype = "lp",
         degree.select = "exhaustive",
-        search.engine = "cell",
         degree.min = 0L,
         degree.max = 1L,
         bwtype = "fixed",
@@ -495,7 +493,7 @@ test_that("npindexbw automatic degree search emits staged progress output", {
     )
   )
 
-  expect_true(any(grepl("Exhaustive degree/bw 0/", msgs) & grepl("best (0)", msgs, fixed = TRUE)))
+  expect_true(any(grepl("Automatic polynomial degree search baseline \\(0\\)", msgs)))
   expect_true(any(grepl("(Selecting degree and bandwidth|NOMAD degree/bw|Exhaustive degree/bw|Auto:NOMAD degree/bw|Auto:exhaustive degree/bw)", msgs)))
   expect_true(any(grepl("exhaustive", msgs)))
   expect_true(any(grepl("best (", msgs, fixed = TRUE)))

--- a/tests/testthat/test-npindexbw-nomad-payload-contract.R
+++ b/tests/testthat/test-npindexbw-nomad-payload-contract.R
@@ -27,16 +27,6 @@ with_nprmpi_npindex_nomad_payload_bindings <- function(bindings, code) {
   eval(code, envir = parent.frame())
 }
 
-npindex_nomad_expected_internal_start <- function(ns, xdat, setup) {
-  beta.coord <- get(".npindex_beta_coordinate_setup", envir = ns, inherits = FALSE)(
-    as.matrix(xdat)
-  )
-  expected <- as.numeric(setup$start_matrix.point[1L, ])
-  if (length(setup$beta.free))
-    expected[seq_along(setup$beta.free)] <- beta.coord$to_search(expected[seq_along(setup$beta.free)])
-  expected
-}
-
 test_that("npindexbw retains Powell evaluation counts when Powell does not improve", {
   ns <- asNamespace("npRmpi")
 
@@ -76,8 +66,7 @@ test_that("npindexbw retains Powell evaluation counts when Powell does not impro
                                   random.seed,
                                   remin = FALSE,
                                   degree_spec,
-                                  progress_label,
-                                  ...) {
+                                  progress_label) {
         eval_fun(x0)
         build_payload(
           x0,
@@ -249,7 +238,7 @@ test_that("npindexbw fixed NOMAD route normalizes internal h starts but keeps pu
     )
   )
 
-  expect_equal(captured$x0, npindex_nomad_expected_internal_start(ns, xdat, setup), tolerance = 1e-12)
+  expect_equal(captured$x0, as.numeric(setup$start_matrix.point[1L, ]), tolerance = 1e-12)
   expect_equal(result$restart.starts[[1]], as.numeric(setup$start_matrix.raw[1L, ]), tolerance = 1e-12)
   expect_equal(result$restart.bandwidth.starts[[1]], as.numeric(setup$start_matrix.raw[1L, seq_len(ncol(setup$start_matrix.raw) - 1L)]), tolerance = 1e-12)
   expect_equal(result$restart.results[[1]]$start, as.numeric(setup$start_matrix.raw[1L, ]), tolerance = 1e-12)
@@ -375,7 +364,7 @@ test_that("npindexbw fixed NOMAD route preserves explicit user fixed starts", {
 
   expect_equal(setup$start_matrix.raw[1L, 1L], 1.75, tolerance = 1e-12)
   expect_equal(setup$start_matrix.raw[1L, 2L], 0.25, tolerance = 1e-12)
-  expect_equal(captured$x0, npindex_nomad_expected_internal_start(ns, xdat, setup), tolerance = 1e-12)
+  expect_equal(captured$x0, as.numeric(setup$start_matrix.point[1L, ]), tolerance = 1e-12)
   expect_equal(result$restart.starts[[1]], as.numeric(setup$start_matrix.raw[1L, ]), tolerance = 1e-12)
   expect_equal(result$restart.results[[1]]$start, as.numeric(setup$start_matrix.raw[1L, ]), tolerance = 1e-12)
 })

--- a/tests/testthat/test-npscoef.R
+++ b/tests/testthat/test-npscoef.R
@@ -53,40 +53,6 @@ test_that("npscoefbw records ll/lp controls", {
   expect_identical(bw.lp$basis, "tensor")
 })
 
-test_that("npscoefbw passes optim.method to optim", {
-  if (!spawn_mpi_slaves()) skip("Could not spawn MPI slaves")
-  on.exit(close_mpi_slaves(), add = TRUE)
-
-  set.seed(44)
-  n <- 60
-  x <- runif(n)
-  z <- runif(n)
-  y <- (0.4 + sin(2 * pi * x)) * z + rnorm(n, sd = 0.08)
-
-  seen <- new.env(parent = emptyenv())
-  seen$method <- character()
-  tracer <- substitute({
-    assign("method", c(get("method", envir = SEEN), method), envir = SEEN)
-  }, list(SEEN = seen))
-
-  suppressMessages(trace(stats::optim, tracer = tracer, print = FALSE))
-  on.exit(suppressMessages(untrace(stats::optim)), add = TRUE)
-
-  suppressWarnings(npscoefbw(
-    xdat = x,
-    zdat = z,
-    ydat = y,
-    regtype = "lc",
-    bwmethod = "cv.ls",
-    nmulti = 1L,
-    optim.method = "BFGS",
-    optim.maxit = 5L,
-    optim.maxattempts = 1L
-  ))
-
-  expect_true("BFGS" %in% seen$method)
-})
-
 test_that("npscoef direct route accepts omitted tzdat with explicit bandwidths", {
   if (!spawn_mpi_slaves()) skip("Could not spawn MPI slaves")
   on.exit(close_mpi_slaves(), add = TRUE)

--- a/tests/testthat/test-progress-npindex-fit-contract.R
+++ b/tests/testthat/test-progress-npindex-fit-contract.R
@@ -153,7 +153,7 @@ test_that("npindex lp bw to fit route hands off into the regression fit surface"
   )
 
   lines <- npindex_fit_progress_lines(actual)
-  bandwidth.pos <- grep("^\\[npRmpi\\] (Degree/bw|Bandwidth selection)", lines)
+  bandwidth.pos <- grep("^\\[npRmpi\\] Bandwidth selection \\(", lines)
   fit.start.pos <- grep(
     "^\\[npRmpi\\] Fitting regression 0/24 \\(0\\.0%, elapsed 0\\.0s, eta 0\\.0s\\): starting$",
     lines


### PR DESCRIPTION
## Summary

This draft PR is the merge-safe promotion branch for the validated `npRmpi` keeper recovery tree.

It starts from the current `npRmpi` head `313c7e8cede90312efa52e85dadad70ac251a326` and replaces the source tree with the already validated recovery branch tree from `codex/recover-keeper-npRmpi-from-20260626` at `a43d2e4fb292dd3026b747a4229f957e533418cb`.

This shape is intentional: merging this PR into `npRmpi` should remove quarantined rogue-agent changes that are present on current `npRmpi`, instead of preserving them through an ordinary merge from the June 26 recovery branch.

## Validation

Proof root:

`/Users/jracine/Development/tmp/merge_safe_promotion_20260630_073543_EEST`

Passed gates:

- Fresh private install of `npRmpi` from this promotion branch.
- Keeper sentinel with `nslaves = 1`: `proof/npRmpi_keeper_candidate_nslaves1.tsv`.
- Keeper sentinel with `nslaves = 2`: `proof/npRmpi_keeper_candidate_nslaves2.tsv`.
- Cross-package parity with `np` promotion branch, `nslaves = 1`: `proof/cross_package_parity_nslaves1.tsv`.
- Cross-package parity with `np` promotion branch, `nslaves = 2`: `proof/cross_package_parity_nslaves2.tsv`.
- Tarball-first `R CMD check --as-cran` from `check/npRmpi/npRmpi_0.70-5.tar.gz`: exited 0 with `Status: 1 WARNING, 1 NOTE`.

The warning is the local missing `checkbashisms` script. The note is CRAN incoming `Days since last update: 4`.

## Review Notes

The committed tree is intentionally identical to `codex/recover-keeper-npRmpi-from-20260626`; the diff is the cleanup required to make current `npRmpi` match that validated tree.
