### PR TITLE
[codex] Repair npreghat LP gradient owner/apply routing (npRmpi)

### DIFF
--- a/R/np.reghat.R
+++ b/R/np.reghat.R
@@ -1377,11 +1377,26 @@ npreghat.rbandwidth <-
     first.derivative.request <- (sum(s) == 1L) && all(s %in% c(0L, 1L))
     simple.operator.request <- (sum(s) == 0L) || first.derivative.request
 
+    lp.degree0.lc.derivative.route <- identical(regtype, "lp") &&
+      first.derivative.request &&
+      npGlpDegree0FirstDerivativeLcOk(
+        regtype.engine = reg.spec$regtype.engine,
+        degree.engine = reg.spec$degree.engine,
+        gradient.order = rep.int(1L, ncon),
+        ncon = ncon
+      )
+
+    direct.apply.compatible <- !any(s > 0L) ||
+      !identical(reg.spec$regtype.engine, "lp") ||
+      lp.degree0.lc.derivative.route ||
+      all(reg.spec$degree.engine >= 1L)
+
     direct.apply <- identical(output, "apply") &&
       !is.null(y) &&
       !isTRUE(leave.one.out) &&
       (ncol(y) == 1L) &&
-      simple.operator.request
+      simple.operator.request &&
+      direct.apply.compatible
 
     lc.derivative.exact.route <- identical(regtype, "lc") &&
       first.derivative.request
@@ -1400,6 +1415,7 @@ npreghat.rbandwidth <-
       simple.operator.request &&
       identical(regtype, "lp") &&
       identical(reg.spec$regtype.engine, "lp") &&
+      !lp.degree0.lc.derivative.route &&
       (bws$ncon > 0L)
 
     exact.core.route <- !isTRUE(leave.one.out) &&
@@ -1408,6 +1424,7 @@ npreghat.rbandwidth <-
         exact.lc.kernel.route ||
         exact.ll.kernel.route ||
         exact.lp.kernel.route ||
+        lp.degree0.lc.derivative.route ||
         lc.derivative.exact.route ||
         FALSE
       )
@@ -1465,7 +1482,14 @@ npreghat.rbandwidth <-
     }
 
     if (exact.core.route) {
-      H <- if (lc.derivative.exact.route) {
+      H <- if (lp.degree0.lc.derivative.route) {
+        .npreghat_exact_matrix_from_core(
+          bws = bws,
+          txdat = txdat,
+          exdat = if (no.ex) NULL else exdat,
+          s = s
+        )
+      } else if (lc.derivative.exact.route) {
         .npRmpi_with_local_regression(.npreghat_exact_lc_derivative_matrix_from_npksum_chunked(
           bws = bws,
           txdat = txdat,

--- a/tests/testthat/test-npreghat-generalized-lp-owner-contract.R
+++ b/tests/testthat/test-npreghat-generalized-lp-owner-contract.R
@@ -140,3 +140,53 @@ npreghat_generalized_lp_derivative_owner_case <- function() {
 test_that("npRmpi generalized higher-degree lp derivative owner matches npreg and apply", {
   npreghat_generalized_lp_derivative_owner_case()
 })
+
+npreghat_lp_gradient_apply_contract_case <- function() {
+  skip_on_cran()
+
+  env <- npRmpi_subprocess_env(c("NP_RMPI_NO_REUSE_SLAVES=1"))
+  skip_if(is.null(env), "local npRmpi install unavailable for subprocess smoke")
+
+  ok_tag <- "NPREGHAT_LP_GRADIENT_APPLY_CONTRACT_OK"
+  lines <- c(
+    "suppressPackageStartupMessages(library(npRmpi))",
+    "options(npRmpi.autodispatch=TRUE, np.messages=FALSE)",
+    "npRmpi.init(nslaves=1, quiet=TRUE)",
+    "on.exit(try(npRmpi.quit(force=TRUE), silent=TRUE), add=TRUE)",
+    "set.seed(20260630)",
+    "n <- 18L",
+    "x1 <- runif(n, -1, 1)",
+    "x2 <- runif(n, -1, 1)",
+    "f <- factor(sample(letters[1:3], n, replace = TRUE))",
+    "tx <- data.frame(x1 = x1, x2 = x2, f = f)",
+    "eta <- x1 + 0.5 * x2 + 0.2 * (as.integer(f) - 2L)",
+    "y1 <- sin(eta) + 0.15 * eta^2",
+    "y2 <- cos(eta) + seq_len(n) / (10 * n)",
+    "Y <- cbind(y1 = y1, y2 = y2)",
+    "check_apply_contract <- function(degree, s, tol = 1e-9) {",
+    "  bw <- npregbw(xdat = tx, ydat = y1, regtype = 'lp', degree = degree, bwtype = 'generalized_nn', bws = c(7, 7, 0.5), bandwidth.compute = FALSE)",
+    "  H <- unclass(npreghat(bws = bw, txdat = tx, s = s))",
+    "  a1 <- npreghat(bws = bw, txdat = tx, y = matrix(y1, ncol = 1L), output = 'apply', s = s)",
+    "  a2 <- npreghat(bws = bw, txdat = tx, y = Y, output = 'apply', s = s)",
+    "  stopifnot(isTRUE(all.equal(as.vector(a1), as.vector(H %*% y1), tolerance = tol)))",
+    "  stopifnot(isTRUE(all.equal(unname(as.matrix(a2)), unname(H %*% Y), tolerance = tol)))",
+    "}",
+    "check_apply_contract(degree = c(0L, 0L), s = c(1L, 0L))",
+    "check_apply_contract(degree = c(1L, 0L), s = c(1L, 0L))",
+    sprintf("cat('%s\\n')", ok_tag)
+  )
+
+  res <- npRmpi_run_rscript_subprocess(
+    lines = lines,
+    timeout = 90L,
+    env = env
+  )
+
+  expect_equal(res$status, 0L, info = paste(res$output, collapse = "\n"))
+  expect_true(any(grepl(ok_tag, res$output, fixed = TRUE)),
+              info = paste(res$output, collapse = "\n"))
+}
+
+test_that("npRmpi lp gradient apply routing covers degree-zero and heterogeneous degrees", {
+  npreghat_lp_gradient_apply_contract_case()
+})


### PR DESCRIPTION
## Summary

This is the MPI-side mirror of the narrow `npreghat()` LP gradient owner/apply routing repair.

It keeps the repair scoped to `R/np.reghat.R` and the existing subprocess-backed owner-contract test file. The change mirrors the serial routing contract while preserving the existing `npRmpi` local-regression wrapper behavior around MPI-sensitive exact paths.

## Validation

Proof root: `/Users/jracine/Development/tmp/npreghat_lp_gradient_branch_promotion_20260630_093522_EEST`

- Fresh private install from branch source passed.
- `npRmpi` public sentinel passed 8/8 with `nslaves = 1` and 8/8 with `nslaves = 2`; local teardown returned the known ignorable exit 137 after pass tables were written.
- Focused `test-npreghat-generalized-lp-owner-contract.R` passed against the final private install with subprocess-backed MPI checks.
- Tarball-first `R CMD check --as-cran` exited 0 with the expected local `checkbashisms` warning only.

## Scope

No native/C changes, no `npindex` changes, no optimizer changes, no default-option changes.
