### PR TITLE
[codex] Repair npreghat LP gradient owner/apply routing (np)

### DIFF
--- a/R/np.reghat.R
+++ b/R/np.reghat.R
@@ -1171,11 +1171,26 @@ npreghat.rbandwidth <-
     first.derivative.request <- (sum(s) == 1L) && all(s %in% c(0L, 1L))
     simple.operator.request <- (sum(s) == 0L) || first.derivative.request
 
+    lp.degree0.lc.derivative.route <- identical(regtype, "lp") &&
+      first.derivative.request &&
+      npGlpDegree0FirstDerivativeLcOk(
+        regtype.engine = reg.spec$regtype.engine,
+        degree.engine = reg.spec$degree.engine,
+        gradient.order = rep.int(1L, ncon),
+        ncon = ncon
+      )
+
+    direct.apply.compatible <- !any(s > 0L) ||
+      !identical(reg.spec$regtype.engine, "lp") ||
+      lp.degree0.lc.derivative.route ||
+      all(reg.spec$degree.engine >= 1L)
+
     direct.apply <- identical(output, "apply") &&
       !is.null(y) &&
       !isTRUE(leave.one.out) &&
       (ncol(y) == 1L) &&
-      simple.operator.request
+      simple.operator.request &&
+      direct.apply.compatible
 
     lc.derivative.exact.route <- identical(regtype, "lc") &&
       first.derivative.request
@@ -1194,6 +1209,7 @@ npreghat.rbandwidth <-
       simple.operator.request &&
       identical(regtype, "lp") &&
       identical(reg.spec$regtype.engine, "lp") &&
+      !lp.degree0.lc.derivative.route &&
       (bws$ncon > 0L)
 
     exact.core.route <- !isTRUE(leave.one.out) &&
@@ -1202,6 +1218,7 @@ npreghat.rbandwidth <-
         exact.lc.kernel.route ||
         exact.ll.kernel.route ||
         exact.lp.kernel.route ||
+        lp.degree0.lc.derivative.route ||
         lc.derivative.exact.route ||
         FALSE
       )
@@ -1272,7 +1289,14 @@ npreghat.rbandwidth <-
     }
 
     if (exact.core.route) {
-      H <- if (lc.derivative.exact.route) {
+      H <- if (lp.degree0.lc.derivative.route) {
+        .npreghat_exact_matrix_from_core(
+          bws = bws,
+          txdat = txdat,
+          exdat = if (no.ex) NULL else exdat,
+          s = s
+        )
+      } else if (lc.derivative.exact.route) {
         .npreghat_exact_lc_derivative_matrix_from_npksum_chunked(
           bws = bws,
           txdat = txdat,

--- a/tests/testthat/test-npreghat-generalized-lp-owner-contract.R
+++ b/tests/testthat/test-npreghat-generalized-lp-owner-contract.R
@@ -144,3 +144,50 @@ test_that("generalized higher-degree lp derivative owner matches npreg on evalua
            s = c(1L, 0L),
            basis = "tensor")
 })
+
+test_that("lp gradient owner/apply routing covers degree-zero and heterogeneous degrees", {
+  set.seed(20260630)
+  n <- 18L
+  x1 <- runif(n, -1, 1)
+  x2 <- runif(n, -1, 1)
+  f <- factor(sample(letters[1:3], n, replace = TRUE))
+  tx <- data.frame(x1 = x1, x2 = x2, f = f)
+  eta <- x1 + 0.5 * x2 + 0.2 * (as.integer(f) - 2L)
+  y1 <- sin(eta) + 0.15 * eta^2
+  y2 <- cos(eta) + seq_len(n) / (10 * n)
+  Y <- cbind(y1 = y1, y2 = y2)
+
+  check_apply_contract <- function(degree, s, tol = 1e-9) {
+    bw <- npregbw(
+      xdat = tx,
+      ydat = y1,
+      regtype = "lp",
+      degree = degree,
+      bwtype = "generalized_nn",
+      bws = c(7, 7, 0.5),
+      bandwidth.compute = FALSE
+    )
+
+    H <- unclass(npreghat(bws = bw, txdat = tx, s = s))
+    a1 <- npreghat(
+      bws = bw,
+      txdat = tx,
+      y = matrix(y1, ncol = 1L),
+      output = "apply",
+      s = s
+    )
+    a2 <- npreghat(
+      bws = bw,
+      txdat = tx,
+      y = Y,
+      output = "apply",
+      s = s
+    )
+
+    expect_equal(as.vector(a1), as.vector(H %*% y1), tolerance = tol)
+    expect_equal(unname(as.matrix(a2)), unname(H %*% Y), tolerance = tol)
+  }
+
+  check_apply_contract(degree = c(0L, 0L), s = c(1L, 0L))
+  check_apply_contract(degree = c(1L, 0L), s = c(1L, 0L))
+})


### PR DESCRIPTION
## Summary

This is a narrow serial-package repair for the `npreghat()` LP gradient owner/apply routing contract.

It keeps the repair scoped to `R/np.reghat.R` and the existing focused owner-contract test file. The change routes LP degree-0 first-derivative requests through the exact core owner, prevents the LP kernel route from claiming that degree-0 derivative case, and prevents single-RHS `output = "apply"` from taking an incompatible direct shortcut for heterogeneous LP degree vectors.

## Validation

Proof root: `/Users/jracine/Development/tmp/npreghat_lp_gradient_branch_promotion_20260630_093522_EEST`

- Fresh private install from branch source passed.
- Serial 144-row oracle passed with 0 flagged rows.
- Focused `test-npreghat-generalized-lp-owner-contract.R` passed against the final private install.
- Tarball-first `R CMD check --as-cran` exited 0 with the expected local `checkbashisms` warning only.

## Scope

No native/C changes, no `npindex` changes, no optimizer changes, no default-option changes.
